### PR TITLE
Optimize locking

### DIFF
--- a/src/append/console.rs
+++ b/src/append/console.rs
@@ -24,7 +24,7 @@ impl fmt::Debug for ConsoleAppender {
 }
 
 impl Append for ConsoleAppender {
-    fn append(&mut self, record: &LogRecord) -> Result<(), Box<Error>> {
+    fn append(&self, record: &LogRecord) -> Result<(), Box<Error>> {
         let mut stdout = SimpleWriter(self.stdout.lock());
         try!(self.encoder.encode(&mut stdout, record));
         try!(stdout.flush());

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -25,7 +25,7 @@ impl<W: io::Write> io::Write for SimpleWriter<W> {
 impl<W: io::Write> encode::Write for SimpleWriter<W> {}
 
 /// A trait implemented by log4rs appenders.
-pub trait Append: fmt::Debug + Send + 'static {
+pub trait Append: fmt::Debug + Send + Sync + 'static {
     /// Processes the provided `LogRecord`.
-    fn append(&mut self, record: &LogRecord) -> Result<(), Box<Error>>;
+    fn append(&self, record: &LogRecord) -> Result<(), Box<Error>>;
 }

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -8,9 +8,9 @@ pub mod pattern;
 
 /// A trait implemented by types that can serialize a `LogRecord` into a
 /// `Write`r.
-pub trait Encode: fmt::Debug + Send + 'static {
+pub trait Encode: fmt::Debug + Send + Sync + 'static {
     /// Encodes the `LogRecord` into bytes and writes them.
-    fn encode(&mut self, w: &mut Write, record: &LogRecord) -> io::Result<()>;
+    fn encode(&self, w: &mut Write, record: &LogRecord) -> io::Result<()>;
 }
 
 /// A trait for types that an `Encode`r will write to.

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -102,7 +102,7 @@ impl Default for PatternEncoder {
 }
 
 impl Encode for PatternEncoder {
-    fn encode(&mut self, w: &mut encode::Write, record: &LogRecord) -> io::Result<()> {
+    fn encode(&self, w: &mut encode::Write, record: &LogRecord) -> io::Result<()> {
         let location = Location {
             module_path: record.location().module_path(),
             file: record.location().file(),

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -6,9 +6,9 @@ use log::LogRecord;
 pub mod threshold;
 
 /// The trait implemented by log4rs filters.
-pub trait Filter: fmt::Debug + Send + 'static {
+pub trait Filter: fmt::Debug + Send + Sync + 'static {
     /// Filters a log event.
-    fn filter(&mut self, record: &LogRecord) -> Response;
+    fn filter(&self, record: &LogRecord) -> Response;
 }
 
 /// The response returned by a filter.

--- a/src/filter/threshold.rs
+++ b/src/filter/threshold.rs
@@ -18,7 +18,7 @@ impl ThresholdFilter {
 }
 
 impl Filter for ThresholdFilter {
-    fn filter(&mut self, record: &LogRecord) -> Response {
+    fn filter(&self, record: &LogRecord) -> Response {
         if record.level() > self.level {
             Response::Reject
         } else {


### PR DESCRIPTION
The previous locking strategy required taking a mutex regardless of whether the record is accepted by the filter. This leads to a lot of synchronization in multithreaded programs making extensive use of log
macros. Since a common code path is calling log, applying a filter, and throwing the record away, it makes sense to be able to do this in parallel. To accomplish this, the `inner` Mutex was changed to a RwLock. Since `&mut self` methods can't be called with a read lock, the Append, Filter, and Encode traits need to implement Sync, and their implementors must use interior mutability where needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sfackler/log4rs/13)
<!-- Reviewable:end -->
