### PR TITLE
Escaping round and curly brackets "(){}" with backslash in pattern format strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ typemap = "0.3"
 serde_json = { version = "0.7", optional = true }
 serde_yaml = { version = "0.2", optional = true }
 toml = { version = "0.1.28", optional = true, default_features = false, features = ["serde"] }
+regex = "*"
+lazy_static = "*"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2"

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -811,4 +811,18 @@ mod tests {
         assert!(error_free(&PatternEncoder::new("{d(%+)(local)}")));
         assert!(!error_free(&PatternEncoder::new("{d(%+)(foo)}")));
     }
+
+    #[test]
+    fn quote_braces_with_backslash() {
+        let pw = PatternEncoder::new(r"\{\({l}\)\}\/");
+
+        let mut buf = vec![];
+        pw.append_inner(&mut SimpleWriter(&mut buf),
+                        LogLevel::Info,
+                        "",
+                        &LOCATION,
+                        &format_args!("foo"))
+        .unwrap();
+        assert_eq!(buf, br"{(INFO)}\/");
+    }
 }

--- a/src/encode/pattern/parser.rs
+++ b/src/encode/pattern/parser.rs
@@ -181,7 +181,7 @@ impl<'a> Parser<'a> {
     fn text(&mut self, start: usize) -> Piece<'a> {
         while let Some(&(pos, ch)) = self.it.peek() {
             match ch {
-                '{' | '}' | ')' => return Piece::Text(&self.pattern[start..pos]),
+                '{' | '}' | ')' | '\\' => return Piece::Text(&self.pattern[start..pos]),
                 _ => {
                     self.it.next();
                 }
@@ -189,6 +189,7 @@ impl<'a> Parser<'a> {
         }
         Piece::Text(&self.pattern[start..])
     }
+
 }
 
 impl<'a> Iterator for Parser<'a> {
@@ -196,6 +197,30 @@ impl<'a> Iterator for Parser<'a> {
 
     fn next(&mut self) -> Option<Piece<'a>> {
         match self.it.peek() {
+            Some(&(_, '\\')) => {
+                self.it.next();
+                match self.it.peek() {
+                    Some(&(_, '{')) => {
+                        self.it.next();
+                        Some(Piece::Text("{"))
+                    }
+                    Some(&(_, '}')) => {
+                        self.it.next();
+                        Some(Piece::Text("}"))
+                    }
+                    Some(&(_, '(')) => {
+                        self.it.next();
+                        Some(Piece::Text("("))
+                    }
+                    Some(&(_, ')')) => {
+                        self.it.next();
+                        Some(Piece::Text(")"))
+                    }
+                    _ => {
+                        Some(Piece::Text("\\"))
+                    }
+                }
+            }
             Some(&(_, '{')) => {
                 self.it.next();
                 if self.consume('{') {


### PR DESCRIPTION
Hi,

I noticed that there is currently no way of using brackets as text in pattern format string, and curly braces can be escaped by doubling them, so "{{" is printed as "{". 
I added the possibility to escape (){} with a backslash, so "\\(" is printed as "(", etc. Please note that when pattern format string is read from file, backslash needs to be doubled to get past escaping in deserialization. 