### PR TITLE
Fix the problem with append=false in FileAppender

### DIFF
--- a/src/append/file/mod.rs
+++ b/src/append/file/mod.rs
@@ -83,7 +83,7 @@ impl FileAppenderBuilder {
         }
         let file = try!(OpenOptions::new()
                             .write(true)
-                            .append(true)
+                            .append(self.append)
                             .truncate(!self.append)
                             .create(true)
                             .open(&path));
@@ -150,6 +150,15 @@ mod test {
 
         FileAppender::builder()
             .build(tempdir.path().join("foo").join("bar").join("baz.log"))
+            .unwrap();
+    }
+
+    #[test]
+    fn append_false() {
+        let tempdir = TempDir::new("create_directories").unwrap();
+        FileAppender::builder()
+            .append(false)
+            .build(tempdir.path().join("foo.log"))
             .unwrap();
     }
 }


### PR DESCRIPTION
Setting `append = false` on the file appender causes an error now:
```
log4rs: Error deserializing component: Invalid argument (os error 22)
log4rs: Error creating config: Reference to nonexistent appender: requests
```
The problem is that `std::fs::OpenOptions` fails on `.write(true).append(true).truncate(true)`. In case of `append=false` it must be changed to `.write(true).append(false).truncate(true)`.

The commit adds a test to reproduce the problem and fixes it.