### PR TITLE
Support thread IDs in both JSON and pattern encoders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## New
+
+* Support thread IDs in both JSON and pattern encoders.
+
 ## [0.8.0] - 2017-12-25
 
 ## New

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ compound_policy = []
 delete_roller = []
 fixed_window_roller = []
 size_trigger = []
-json_encoder = ["serde", "serde_json", "chrono", "log-mdc", "serde_derive", "log/serde"]
-pattern_encoder = ["chrono", "log-mdc"]
+json_encoder = ["serde", "serde_json", "chrono", "log-mdc", "serde_derive", "log/serde", "thread-id"]
+pattern_encoder = ["chrono", "log-mdc", "thread-id"]
 ansi_writer = []
 console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
@@ -58,6 +58,7 @@ log-mdc = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde-value = { version = "0.5", optional = true }
+thread-id = { version = "3.3", optional = true }
 typemap = { version = "0.3", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.7", optional = true }

--- a/src/encode/json.rs
+++ b/src/encode/json.rs
@@ -18,6 +18,7 @@
 //!     "level": "INFO",
 //!     "target": "foo::bar",
 //!     "thread": "main",
+//!     "thread_id": 123,
 //!     "mdc": {
 //!         "request_id": "123e4567-e89b-12d3-a456-426655440000"
 //!     }
@@ -34,6 +35,7 @@ use std::thread;
 use std::option;
 use serde::ser::{self, Serialize, SerializeMap};
 use serde_json;
+use thread_id;
 
 use encode::{Encode, Write, NEWLINE};
 #[cfg(feature = "file")]
@@ -75,6 +77,7 @@ impl JsonEncoder {
             line: record.line(),
             target: record.target(),
             thread: thread.name(),
+            thread_id: thread_id::get(),
             mdc: Mdc,
         };
         message.serialize(&mut serde_json::Serializer::new(&mut *w))?;
@@ -99,6 +102,7 @@ struct Message<'a> {
     level: Level,
     target: &'a str,
     thread: Option<&'a str>,
+    thread_id: usize,
     mdc: Mdc,
 }
 
@@ -201,7 +205,7 @@ mod test {
         let expected = format!(
             "{{\"time\":\"{}\",\"message\":\"{}\",\"module_path\":\"{}\",\
              \"file\":\"{}\",\"line\":{},\"level\":\"{}\",\"target\":\"{}\",\
-             \"thread\":\"{}\",\"mdc\":{{\"foo\":\"bar\"}}}}",
+             \"thread\":\"{}\",\"thread_id\":{},\"mdc\":{{\"foo\":\"bar\"}}}}",
             time.to_rfc3339(),
             message,
             module_path,
@@ -209,7 +213,8 @@ mod test {
             line,
             level,
             target,
-            thread
+            thread,
+            thread_id::get(),
         );
         assert_eq!(expected, String::from_utf8(buf).unwrap().trim());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,8 @@ extern crate serde_value;
 extern crate serde_xml_rs;
 #[cfg(feature = "serde_yaml")]
 extern crate serde_yaml;
+#[cfg(feature = "thread-id")]
+extern crate thread_id;
 #[cfg(feature = "toml")]
 extern crate toml;
 #[cfg(feature = "typemap")]


### PR DESCRIPTION
Thread names are supported already, but this is definitely not enough.
Third-party libraries may not set thread names at all or use the
same name for multiple threads.