### PR TITLE
Use the same timestamp when record is encoded using multiple encoders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## New
+
+* The same timestamp is used for log record when multiple appenders/encoders
+are used.
+
 ## [0.8.0] - 2017-12-25
 
 ## New

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ compound_policy = []
 delete_roller = []
 fixed_window_roller = []
 size_trigger = []
-json_encoder = ["serde", "serde_json", "chrono", "log-mdc", "serde_derive", "log/serde"]
-pattern_encoder = ["chrono", "log-mdc"]
+json_encoder = ["serde", "serde_json", "log-mdc", "serde_derive", "log/serde"]
+pattern_encoder = ["log-mdc"]
 ansi_writer = []
 console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
@@ -48,7 +48,7 @@ gzip = ["flate2"]
 
 [dependencies]
 antidote = { version = "1.0", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4" }
 crossbeam = "0.3"
 flate2 = { version = "1.0", optional = true }
 fnv = "1.0"

--- a/src/append/console.rs
+++ b/src/append/console.rs
@@ -17,6 +17,7 @@ use encode::writer::console::{ConsoleWriter, ConsoleWriterLock};
 #[cfg(feature = "file")]
 use file::{Deserialize, Deserializers};
 use priv_io::{StdWriter, StdWriterLock};
+use record::ExtendedRecord;
 
 /// The console appender's configuration.
 #[cfg(feature = "file")]
@@ -110,7 +111,7 @@ impl fmt::Debug for ConsoleAppender {
 }
 
 impl Append for ConsoleAppender {
-    fn append(&self, record: &Record) -> Result<(), Box<Error + Sync + Send>> {
+    fn append(&self, record: &ExtendedRecord) -> Result<(), Box<Error + Sync + Send>> {
         let mut writer = self.writer.lock();
         self.encoder.encode(&mut writer, record)?;
         writer.flush()?;

--- a/src/append/file.rs
+++ b/src/append/file.rs
@@ -18,6 +18,7 @@ use encode::pattern::PatternEncoder;
 use encode::writer::simple::SimpleWriter;
 #[cfg(feature = "file")]
 use file::{Deserialize, Deserializers};
+use record::ExtendedRecord;
 
 /// The file appender's configuration.
 #[cfg(feature = "file")]
@@ -46,7 +47,7 @@ impl fmt::Debug for FileAppender {
 }
 
 impl Append for FileAppender {
-    fn append(&self, record: &Record) -> Result<(), Box<Error + Sync + Send>> {
+    fn append(&self, record: &ExtendedRecord) -> Result<(), Box<Error + Sync + Send>> {
         let mut file = self.file.lock();
         self.encoder.encode(&mut *file, record)?;
         file.flush()?;

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use file::Deserializable;
 #[cfg(feature = "file")]
 use filter::FilterConfig;
+use record::ExtendedRecord;
 
 #[cfg(feature = "file_appender")]
 pub mod file;
@@ -28,7 +29,7 @@ pub mod rolling_file;
 /// to a file or the console.
 pub trait Append: fmt::Debug + Send + Sync + 'static {
     /// Processes the provided `Record`.
-    fn append(&self, record: &Record) -> Result<(), Box<Error + Sync + Send>>;
+    fn append(&self, record: &ExtendedRecord) -> Result<(), Box<Error + Sync + Send>>;
 
     /// Flushes all in-flight records.
     fn flush(&self);
@@ -42,8 +43,8 @@ impl Deserializable for Append {
 }
 
 impl<T: Log + fmt::Debug + 'static> Append for T {
-    fn append(&self, record: &Record) -> Result<(), Box<Error + Sync + Send>> {
-        self.log(record);
+    fn append(&self, record: &ExtendedRecord) -> Result<(), Box<Error + Sync + Send>> {
+        self.log(record.record());
         Ok(())
     }
 

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -37,6 +37,7 @@ use encode::EncoderConfig;
 use encode::pattern::PatternEncoder;
 #[cfg(feature = "file")]
 use file::{Deserialize, Deserializers};
+use record::ExtendedRecord;
 
 pub mod policy;
 
@@ -154,7 +155,7 @@ impl fmt::Debug for RollingFileAppender {
 }
 
 impl Append for RollingFileAppender {
-    fn append(&self, record: &Record) -> Result<(), Box<Error + Sync + Send>> {
+    fn append(&self, record: &ExtendedRecord) -> Result<(), Box<Error + Sync + Send>> {
         let mut writer = self.writer.lock();
 
         let len = {

--- a/src/encode/json.rs
+++ b/src/encode/json.rs
@@ -38,6 +38,7 @@ use serde_json;
 use encode::{Encode, Write, NEWLINE};
 #[cfg(feature = "file")]
 use file::{Deserialize, Deserializers};
+use record::ExtendedRecord;
 
 /// The JSON encoder's configuration
 #[cfg(feature = "file")]
@@ -84,8 +85,8 @@ impl JsonEncoder {
 }
 
 impl Encode for JsonEncoder {
-    fn encode(&self, w: &mut Write, record: &Record) -> Result<(), Box<Error + Sync + Send>> {
-        self.encode_inner(w, Local::now(), record)
+    fn encode(&self, w: &mut Write, record: &ExtendedRecord) -> Result<(), Box<Error + Sync + Send>> {
+        self.encode_inner(w, record.timestamp().with_timezone(&Local), record.record())
     }
 }
 

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -13,6 +13,7 @@ use std::io;
 
 #[cfg(feature = "file")]
 use file::Deserializable;
+use record::ExtendedRecord;
 
 #[cfg(feature = "json_encoder")]
 pub mod json;
@@ -34,7 +35,7 @@ const NEWLINE: &'static str = "\n";
 /// output.
 pub trait Encode: fmt::Debug + Send + Sync + 'static {
     /// Encodes the `Record` into bytes and writes them.
-    fn encode(&self, w: &mut Write, record: &Record) -> Result<(), Box<Error + Sync + Send>>;
+    fn encode(&self, w: &mut Write, record: &ExtendedRecord) -> Result<(), Box<Error + Sync + Send>>;
 }
 
 #[cfg(feature = "file")]

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -116,7 +116,7 @@
 //!
 //! [MDC]: https://crates.io/crates/log-mdc
 
-use chrono::{Local, Utc};
+use chrono::Local;
 use log::{Level, Record};
 use log_mdc;
 use std::default::Default;
@@ -129,6 +129,7 @@ use encode::pattern::parser::{Alignment, Parameters, Parser, Piece};
 use encode::{self, Color, Encode, Style, NEWLINE};
 #[cfg(feature = "file")]
 use file::{Deserialize, Deserializers};
+use record::ExtendedRecord;
 
 mod parser;
 
@@ -300,7 +301,7 @@ enum Chunk {
 }
 
 impl Chunk {
-    fn encode(&self, w: &mut encode::Write, record: &Record) -> io::Result<()> {
+    fn encode(&self, w: &mut encode::Write, record: &ExtendedRecord) -> io::Result<()> {
         match *self {
             Chunk::Text(ref s) => w.write_all(s.as_bytes()),
             Chunk::Formatted {
@@ -540,24 +541,24 @@ enum FormattedChunk {
 }
 
 impl FormattedChunk {
-    fn encode(&self, w: &mut encode::Write, record: &Record) -> io::Result<()> {
+    fn encode(&self, w: &mut encode::Write, record: &ExtendedRecord) -> io::Result<()> {
         match *self {
-            FormattedChunk::Time(ref fmt, Timezone::Utc) => write!(w, "{}", Utc::now().format(fmt)),
+            FormattedChunk::Time(ref fmt, Timezone::Utc) => write!(w, "{}", record.timestamp().format(fmt)),
             FormattedChunk::Time(ref fmt, Timezone::Local) => {
-                write!(w, "{}", Local::now().format(fmt))
+                write!(w, "{}", record.timestamp().with_timezone(&Local).format(fmt))
             }
-            FormattedChunk::Level => write!(w, "{}", record.level()),
-            FormattedChunk::Message => w.write_fmt(*record.args()),
-            FormattedChunk::Module => w.write_all(record.module_path().unwrap_or("???").as_bytes()),
-            FormattedChunk::File => w.write_all(record.file().unwrap_or("???").as_bytes()),
-            FormattedChunk::Line => match record.line() {
+            FormattedChunk::Level => write!(w, "{}", record.record().level()),
+            FormattedChunk::Message => w.write_fmt(*record.record().args()),
+            FormattedChunk::Module => w.write_all(record.record().module_path().unwrap_or("???").as_bytes()),
+            FormattedChunk::File => w.write_all(record.record().file().unwrap_or("???").as_bytes()),
+            FormattedChunk::Line => match record.record().line() {
                 Some(line) => write!(w, "{}", line),
                 None => w.write_all(b"???"),
             },
             FormattedChunk::Thread => {
                 w.write_all(thread::current().name().unwrap_or("unnamed").as_bytes())
             }
-            FormattedChunk::Target => w.write_all(record.target().as_bytes()),
+            FormattedChunk::Target => w.write_all(record.record().target().as_bytes()),
             FormattedChunk::Newline => w.write_all(NEWLINE.as_bytes()),
             FormattedChunk::Align(ref chunks) => {
                 for chunk in chunks {
@@ -566,7 +567,7 @@ impl FormattedChunk {
                 Ok(())
             }
             FormattedChunk::Highlight(ref chunks) => {
-                match record.level() {
+                match record.record().level() {
                     Level::Error => {
                         w.set_style(Style::new().text(Color::Red).intense(true))?;
                     }
@@ -577,7 +578,7 @@ impl FormattedChunk {
                 for chunk in chunks {
                     chunk.encode(w, record)?;
                 }
-                match record.level() {
+                match record.record().level() {
                     Level::Error | Level::Warn | Level::Info => w.set_style(&Style::new())?,
                     _ => {}
                 }
@@ -615,7 +616,7 @@ impl Encode for PatternEncoder {
     fn encode(
         &self,
         w: &mut encode::Write,
-        record: &Record,
+        record: &ExtendedRecord,
     ) -> Result<(), Box<Error + Sync + Send>> {
         for chunk in &self.chunks {
             chunk.encode(w, record)?;
@@ -674,6 +675,8 @@ mod tests {
     #[cfg(feature = "simple_writer")]
     use std::thread;
     #[cfg(feature = "simple_writer")]
+    use std::time::Duration;
+    #[cfg(feature = "simple_writer")]
     use log::{Level, Record};
     #[cfg(feature = "simple_writer")]
     use log_mdc;
@@ -683,6 +686,7 @@ mod tests {
     use encode::Encode;
     #[cfg(feature = "simple_writer")]
     use encode::writer::simple::SimpleWriter;
+    use record::ExtendedRecord;
 
     fn error_free(encoder: &PatternEncoder) -> bool {
         encoder.chunks.iter().all(|c| match *c {
@@ -708,14 +712,14 @@ mod tests {
         let mut buf = vec![];
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder()
+            &ExtendedRecord::new(&Record::builder()
                 .level(Level::Debug)
                 .args(format_args!("the message"))
                 .module_path(Some("path"))
                 .file(Some("file"))
                 .line(Some(132))
                 .build(),
-        ).unwrap();
+        )).unwrap();
 
         assert_eq!(buf, &b"DEBUG the message at path in file:132"[..]);
     }
@@ -726,7 +730,8 @@ mod tests {
         thread::spawn(|| {
             let pw = PatternEncoder::new("{T}");
             let mut buf = vec![];
-            pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())
+            pw.encode(&mut SimpleWriter(&mut buf),
+                      &ExtendedRecord::new(&Record::builder().build()))
                 .unwrap();
             assert_eq!(buf, b"unnamed");
         }).join()
@@ -741,7 +746,8 @@ mod tests {
             .spawn(|| {
                 let pw = PatternEncoder::new("{T}");
                 let mut buf = vec![];
-                pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())
+                pw.encode(&mut SimpleWriter(&mut buf),
+                          &ExtendedRecord::new(&Record::builder().build()))
                     .unwrap();
                 assert_eq!(buf, b"foobar");
             })
@@ -764,14 +770,14 @@ mod tests {
         let mut buf = vec![];
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder().args(format_args!("foo")).build(),
+            &ExtendedRecord::new(&Record::builder().args(format_args!("foo")).build()),
         ).unwrap();
         assert_eq!(buf, b"foo~~");
 
         buf.clear();
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder().args(format_args!("foobar!")).build(),
+            &ExtendedRecord::new(&Record::builder().args(format_args!("foobar!")).build()),
         ).unwrap();
         assert_eq!(buf, b"foobar");
     }
@@ -784,14 +790,14 @@ mod tests {
         let mut buf = vec![];
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder().args(format_args!("foo")).build(),
+            &ExtendedRecord::new(&Record::builder().args(format_args!("foo")).build()),
         ).unwrap();
         assert_eq!(buf, b"~~foo");
 
         buf.clear();
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder().args(format_args!("foobar!")).build(),
+            &ExtendedRecord::new(&Record::builder().args(format_args!("foobar!")).build()),
         ).unwrap();
         assert_eq!(buf, b"foobar");
     }
@@ -804,11 +810,11 @@ mod tests {
         let mut buf = vec![];
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder()
+            &ExtendedRecord::new(&Record::builder()
                 .level(Level::Info)
                 .args(format_args!("foobar!"))
                 .build(),
-        ).unwrap();
+        )).unwrap();
         assert_eq!(buf, b"INFO foobar!   ");
     }
 
@@ -820,11 +826,11 @@ mod tests {
         let mut buf = vec![];
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder()
+            &ExtendedRecord::new(&Record::builder()
                 .level(Level::Info)
                 .args(format_args!("foobar!"))
                 .build(),
-        ).unwrap();
+        )).unwrap();
         assert_eq!(buf, b"   INFO foobar!");
     }
 
@@ -855,7 +861,7 @@ mod tests {
         let mut buf = vec![];
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder().args(format_args!("foobar!")).build(),
+            &ExtendedRecord::new(&Record::builder().args(format_args!("foobar!")).build()),
         ).unwrap();
         assert_eq!(buf, b"{foobar!()}");
     }
@@ -868,7 +874,7 @@ mod tests {
         let mut buf = vec![];
         pw.encode(
             &mut SimpleWriter(&mut buf),
-            &Record::builder().level(Level::Info).build(),
+            &ExtendedRecord::new(&Record::builder().level(Level::Info).build()),
         ).unwrap();
         assert_eq!(buf, br"{(INFO)}\");
     }
@@ -880,7 +886,8 @@ mod tests {
         log_mdc::insert("user_id", "mdc value");
 
         let mut buf = vec![];
-        pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())
+        pw.encode(&mut SimpleWriter(&mut buf),
+                  &ExtendedRecord::new(&Record::builder().build()))
             .unwrap();
 
         assert_eq!(buf, b"mdc value");
@@ -892,7 +899,8 @@ mod tests {
         let pw = PatternEncoder::new("{X(user_id)}");
 
         let mut buf = vec![];
-        pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())
+        pw.encode(&mut SimpleWriter(&mut buf),
+                  &ExtendedRecord::new(&Record::builder().build()))
             .unwrap();
 
         assert_eq!(buf, b"");
@@ -904,9 +912,31 @@ mod tests {
         let pw = PatternEncoder::new("{X(user_id)(missing value)}");
 
         let mut buf = vec![];
-        pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())
+        pw.encode(&mut SimpleWriter(&mut buf),
+                  &ExtendedRecord::new(&Record::builder().build()))
             .unwrap();
 
         assert_eq!(buf, b"missing value");
+    }
+
+    #[test]
+    #[cfg(feature = "simple_writer")]
+    fn same_timestamp() {
+        let pw1 = PatternEncoder::new("{d}");
+        let pw2 = PatternEncoder::new("{d}");
+        let record = Record::builder().build();
+        let extended_record = ExtendedRecord::new(&record);
+
+        let mut buf1 = vec![];
+        pw1.encode(&mut SimpleWriter(&mut buf1), &extended_record)
+            .unwrap();
+
+        thread::sleep(Duration::from_millis(100));
+
+        let mut buf2 = vec![];
+        pw2.encode(&mut SimpleWriter(&mut buf2), &extended_record)
+            .unwrap();
+
+        assert_eq!(buf1, buf2);
     }
 }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 
 #[cfg(feature = "file")]
 use file::Deserializable;
+use record::ExtendedRecord;
 
 #[cfg(feature = "threshold_filter")]
 pub mod threshold;
@@ -21,7 +22,7 @@ pub mod threshold;
 /// sent to that appender.
 pub trait Filter: fmt::Debug + Send + Sync + 'static {
     /// Filters a log event.
-    fn filter(&self, record: &Record) -> Response;
+    fn filter(&self, record: &ExtendedRecord) -> Response;
 }
 
 #[cfg(feature = "file")]

--- a/src/filter/threshold.rs
+++ b/src/filter/threshold.rs
@@ -9,6 +9,7 @@ use std::error::Error;
 #[cfg(feature = "file")]
 use file::{Deserialize, Deserializers};
 use filter::{Filter, Response};
+use record::ExtendedRecord;
 
 /// The threshold filter's configuration.
 #[cfg(feature = "file")]
@@ -31,8 +32,8 @@ impl ThresholdFilter {
 }
 
 impl Filter for ThresholdFilter {
-    fn filter(&self, record: &Record) -> Response {
-        if record.level() > self.level {
+    fn filter(&self, record: &ExtendedRecord) -> Response {
+        if record.record().level() > self.level {
             Response::Reject
         } else {
             Response::Neutral

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,0 +1,43 @@
+use std::cell::Cell;
+
+use chrono::{DateTime, Utc};
+use log::Record;
+
+/// Wrapper around log::Record.
+///
+/// Stores additional information not provided by `log::Record`.
+#[derive(Debug)]
+pub struct ExtendedRecord<'a> {
+    record: &'a Record<'a>,
+    lazy_timestamp: Cell<Option<DateTime<Utc>>>,
+}
+
+impl<'a> ExtendedRecord<'a> {
+    /// Construct new `ExtendedRecord` based on a reference to the `log::Record`.
+    pub fn new(record: &'a Record) -> Self {
+        Self {
+            record,
+            lazy_timestamp: Cell::default(),
+        }
+    }
+
+    /// Return reference to wrapped `log::Record`.
+    pub fn record(&self) -> &Record {
+        self.record
+    }
+
+    /// Return timestamp for this log record.
+    ///
+    /// Timestamp is not provided by the base `log::Record`, so on the first call this function creates new timestamp
+    /// based on the current time, and returns the same value on all subsequent calls.
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        match self.lazy_timestamp.get() {
+            Some(timestamp) => timestamp,
+            None => {
+                let timestamp = Utc::now();
+                self.lazy_timestamp.set(Some(timestamp));
+                timestamp
+            }
+        }
+    }
+}


### PR DESCRIPTION
This simplifies matching the log entries when more than one log appender
is used.

Unfortunately I am not able to figure out how to implement this without breaking the public API.