### PR TITLE
Allow loading config without initializing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ use std::sync::Arc;
 use log::{Level, LevelFilter, Metadata, Record, SetLoggerError};
 
 #[cfg(feature = "file")]
-pub use priv_file::{init_file, Error};
+pub use priv_file::{init_file, load_config_file, Error};
 
 use append::Append;
 use config::Config;

--- a/src/priv_file.rs
+++ b/src/priv_file.rs
@@ -55,6 +55,22 @@ where
     }
 }
 
+/// Loads a log4rs logger configuration from a file.
+///
+/// Unlike `init_file`, this function does not initialize the logger; it only
+/// loads the `Config` and returns it.
+pub fn load_config_file<P>(path: P, deserializers: Deserializers) -> Result<Config, Error>
+where
+    P: AsRef<Path>,
+{
+    let path = path.as_ref();
+    let format = Format::from_path(&path)?;
+    let source = read_config(&path)?;
+    let config = format.parse(&source)?;
+
+    Ok(deserialize(&config, &deserializers))
+}
+
 /// An error initializing the logging framework from a file.
 #[derive(Debug)]
 pub enum Error {


### PR DESCRIPTION
Adds the `load_config_file` function that reads a configuration file,
but does not initialize it as `init_file` does.

We are using this modification to load logging configurations from .yaml files, but change the `Config` programmatically.

Signed-off-by: Logan Seeley <seeley@bitwise.io>