### PR TITLE
Add methods for modifying logging level of Root

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,11 @@ impl Root {
     pub fn appenders(&self) -> &[String] {
         &self.appenders
     }
+
+    /// Sets the minimum level of log messages that the root logger will accept.
+    pub fn set_level(&mut self, level: LevelFilter) {
+        self.level = level;
+    }
 }
 
 /// A builder for `Root`s.
@@ -258,6 +263,11 @@ impl Config {
     /// Returns the `Root` associated with the `Config`.
     pub fn root(&self) -> &Root {
         &self.root
+    }
+
+    /// Returns a mutable handle for the `Root` associated with the `Config`.
+    pub fn root_mut(&mut self) -> &mut Root {
+        &mut self.root
     }
 
     /// Returns the `Logger`s associated with the `Config`.


### PR DESCRIPTION
Adds `set_level` methods to `Root` and `Config` objects. This provides
the ability to modify the logging level of `Root` even after `Root` and
`Config` have been built.

We are using this modification to change the logging level of a `Config` that is loaded from a .yaml file based on a verbosity flag that is passed in on the command line.

Signed-off-by: Logan Seeley <seeley@bitwise.io>