### PR TITLE
Update serde_yaml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ serde-value = { version = "0.5", optional = true }
 thread-id = { version = "3.3", optional = true }
 typemap = { version = "0.3", optional = true }
 serde_json = { version = "1.0", optional = true }
-serde_yaml = { version = "0.7", optional = true }
+serde_yaml = { version = "0.8.4", optional = true }
 toml = { version = "0.4", optional = true }
 serde-xml-rs = { version = "0.2.1", optional = true }
 


### PR DESCRIPTION
This will avoid "cargo audit" errors, as serde_yaml 0.7 is vulnerable.