### PR TITLE
Append downcasting & appenders fields disclosure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8.4", optional = true }
 toml = { version = "0.5", optional = true }
 serde-xml-rs = { version = "0.2", optional = true }
+downcast-rs = "1.1.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", optional = true, features = ["handleapi", "minwindef", "processenv", "winbase", "wincon"] }

--- a/src/append/file.rs
+++ b/src/append/file.rs
@@ -64,6 +64,11 @@ impl FileAppender {
             append: true,
         }
     }
+
+    /// The path of config file `FileAppender` writes to.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 /// A builder for `FileAppender`s.

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -26,13 +26,15 @@ pub mod rolling_file;
 ///
 /// Appenders take a log record and processes them, for example, by writing it
 /// to a file or the console.
-pub trait Append: fmt::Debug + Send + Sync + 'static {
+pub trait Append: fmt::Debug + downcast_rs::DowncastSync + Send + Sync + 'static {
     /// Processes the provided `Record`.
     fn append(&self, record: &Record) -> Result<(), Box<dyn Error + Sync + Send>>;
 
     /// Flushes all in-flight records.
     fn flush(&self);
 }
+
+impl_downcast!(sync Append);
 
 #[cfg(feature = "file")]
 impl Deserializable for dyn Append {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,8 @@ extern crate antidote;
 extern crate arc_swap;
 #[cfg(feature = "chrono")]
 extern crate chrono;
+#[macro_use]
+extern crate downcast_rs;
 #[cfg(feature = "flate2")]
 extern crate flate2;
 extern crate fnv;


### PR DESCRIPTION
Covers #99 
@estk is my proposal clear now? These changes makes client code able to walk through all `log4rs::append::Append`ers in`log4rs::config::Config` and try to downcast to any existing concrete `Append`er in order to get necessary information from them.

Now I have a few questions about these changes:
1. Should they be optional? Turning on by cargo feature I mean (I have no idea how to make part of trait constraint of `Append` trait optional without writing trait definition twice)
2. Which other getters should be provided in context of this pull request?
3. Where should this feature be documented?